### PR TITLE
Auto update pre commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.11.8
+    rev: v0.11.9
     hooks:
       # Run the linter
       - id: ruff
@@ -43,7 +43,7 @@ repos:
         args: ['--exclude-files', '.*[^i][^p][^y][^n][^b]$', '--exclude-lines', '"(hash|id|image/\w+)":.*', ]
 
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v4.6.1
+    rev: v4.7.0
     hooks:
       - id: commitizen
       - id: commitizen-branch

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,3 +48,6 @@ repos:
       - id: commitizen
       - id: commitizen-branch
         stages: [pre-push]
+
+ci:
+  autoupdate_schedule: weekly


### PR DESCRIPTION
# Title
chore(ci): 🔁 enable weekly autoupdate of pre-commit hooks

## ✨ Context

This PR enables the automatic weekly update of pre-commit hooks using pre-commit.ci.

## 🧠 Rationale behind the change

Keeping hooks up-to-date ensures consistency, avoids outdated checks, and reduces manual maintenance. This change adds the autoupdate schedule config for the bot to handle updates automatically.

## Type of changes
- [x] 👷 🔧 CI or Configuration Files

## 🛠 What does this PR implement
- Adds ci.autoupdate_schedule: weekly in .pre-commit-config.yaml
- Allows pre-commit.ci to create PRs weekly with updated hook versions
- First step to automate hook maintenance and integration

## 🙈 Missing

N/A

## 🧪 How should this be tested?

- Confirm that .pre-commit-config.yaml includes the ci section
- After merging, wait for pre-commit.ci to open the first auto-update PR
- Monitor https://pre-commit.ci/ for run logs
